### PR TITLE
Fix warnings

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -30,6 +30,9 @@ if not socket.has_ipv6:
 if not hasattr(socket, "IPPROTO_IPV6"):
     # Workaround for http://bugs.python.org/issue6926
     socket.IPPROTO_IPV6 = 41
+if not hasattr(socket, "IPPROTO_IPIP"):
+    # Workaround for http://stackoverflow.com/questions/28754049/scapy-warning-cant-import-layer-inet-module-object-has-no-attribute-ipprot
+    socket.IPPROTO_IPIP = 4
 
 from scapy.config import conf
 from scapy.layers.l2 import *

--- a/scapy/layers/ipsec.py
+++ b/scapy/layers/ipsec.py
@@ -53,6 +53,11 @@ from scapy.layers.inet import IP, UDP
 from scapy.layers.inet6 import IPv6, IPv6ExtHdrHopByHop, IPv6ExtHdrDestOpt, \
     IPv6ExtHdrRouting
 
+if not hasattr(socket, 'IPPROTO_AH'):
+    # workaround like http://stackoverflow.com/questions/28754049/scapy-warning-cant-import-layer-inet-module-object-has-no-attribute-ipprot
+    socket.IPPROTO_AH = 51
+if not hasattr(socket, 'IPPROTO_ESP'):
+    socket.IPPROTO_ESP = 50
 
 #------------------------------------------------------------------------------
 class AH(Packet):


### PR DESCRIPTION
"WARNING: can't import layer inet: 'module' object has no attribute 'IPPROTO_IPIP"

Found this solution:
http://stackoverflow.com/questions/28754049/scapy-warning-cant-import-layer-inet-module-object-has-no-attribute-ipprot

But imo it's more readable to monkey patch the socket object

Applied the same solution for IPPROTO_AH and IPPROTO_ESP